### PR TITLE
Production_ASSAM_Session timeout issue

### DIFF
--- a/src/main/java/com/iemr/admin/data/user/M_User.java
+++ b/src/main/java/com/iemr/admin/data/user/M_User.java
@@ -263,7 +263,7 @@ public class M_User implements Serializable {
 		EmergencyContactNo = emergencyContactNo;
 	}
 
-	public boolean isIsSupervisor() {
+	public Boolean isIsSupervisor() {
 		return IsSupervisor;
 	}
 
@@ -272,7 +272,7 @@ public class M_User implements Serializable {
 	}
 
 	public boolean isDeleted() {
-		return Deleted;
+		return Boolean.TRUE.equals(Deleted);
 	}
 
 	public void setDeleted(boolean deleted) {


### PR DESCRIPTION
## 📋 Description

JIRA ID: AMM-1670

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

This PR addresses issues arising from null Boolean values (Deleted, IsSupervisor) in the User entity when user data is loaded from the database after Redis session expiry.
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

**Root Cause:**

1. Redis session expires after 30 minutes.
2. On cache miss, system fetches user from DB.
3. Unsafe getter methods (return Deleted;) led to NullPointerException.

**Fixes:**

1. Updated isDeleted() method to use Boolean.TRUE.equals(Deleted) for safe null checks.
4. Changed isIsSupervisor() to return Boolean instead of boolean for consistency and null safety.
5. Ensured Redis caching is updated after DB fetch to reduce future misses.

Refer:https://pmp.piramalswasthya.org/confluence/spaces/AMRIT/pages/96043113/AMM-1670+Production_ASSAM_Session+timeout+issue



