### PR TITLE
AMM-118: Expose account lock state in SearchEmployee4

### DIFF
--- a/src/main/java/com/iemr/admin/data/employeemaster/M_User1.java
+++ b/src/main/java/com/iemr/admin/data/employeemaster/M_User1.java
@@ -209,6 +209,9 @@ public class M_User1{
 			@Expose
 			@Column(name = "failed_attempt", insertable = false)
 			private Integer failedAttempt;
+			@Expose
+			@Column(name = "lock_timestamp", insertable = false)
+			private Timestamp lockTimestamp;
 	   public M_User1() {
 		// TODO Auto-generated constructor stub
 	}
@@ -227,6 +230,14 @@ public class M_User1{
 
 	public void setFailedAttempt(Integer failedAttempt) {
 		this.failedAttempt = failedAttempt;
+	}
+
+	public Timestamp getLockTimestamp() {
+		return lockTimestamp;
+	}
+
+	public void setLockTimestamp(Timestamp lockTimestamp) {
+		this.lockTimestamp = lockTimestamp;
 	}
 
 	public Integer getUserID() {

--- a/src/main/java/com/iemr/admin/data/employeemaster/V_Showuser.java
+++ b/src/main/java/com/iemr/admin/data/employeemaster/V_Showuser.java
@@ -246,6 +246,18 @@ public class V_Showuser {
 	   @Column(name="DistrictID")
 	   private Integer districtID;
 
+	   @Expose
+	   @Transient
+	   private Integer failedAttempt;
+
+	   @Expose
+	   @Transient
+	   private Timestamp lockTimestamp;
+
+	   @Expose
+	   @Transient
+	   private Boolean lockedDueToFailedAttempts;
+
 	 
 	 
 	 
@@ -920,6 +932,30 @@ public class V_Showuser {
 
 	public void setDistrictID(Integer districtID) {
 		this.districtID = districtID;
+	}
+
+	public Integer getFailedAttempt() {
+		return failedAttempt;
+	}
+
+	public void setFailedAttempt(Integer failedAttempt) {
+		this.failedAttempt = failedAttempt;
+	}
+
+	public Timestamp getLockTimestamp() {
+		return lockTimestamp;
+	}
+
+	public void setLockTimestamp(Timestamp lockTimestamp) {
+		this.lockTimestamp = lockTimestamp;
+	}
+
+	public Boolean getLockedDueToFailedAttempts() {
+		return lockedDueToFailedAttempts;
+	}
+
+	public void setLockedDueToFailedAttempts(Boolean lockedDueToFailedAttempts) {
+		this.lockedDueToFailedAttempts = lockedDueToFailedAttempts;
 	}
 
 

--- a/src/main/java/com/iemr/admin/repo/employeemaster/EmployeeMasterRepoo.java
+++ b/src/main/java/com/iemr/admin/repo/employeemaster/EmployeeMasterRepoo.java
@@ -22,6 +22,7 @@
 package com.iemr.admin.repo.employeemaster;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -80,4 +81,6 @@ public interface EmployeeMasterRepoo extends CrudRepository<M_User1, Integer>
 	ArrayList<M_User1> getempByDesiganation(@Param("designationID") Integer designationID,@Param("serviceProviderID") Integer serviceProviderID);
 	
 	M_User1 findByUserID(Integer userID);
+
+	List<M_User1> findByUserIDIn(List<Integer> userIDs);
 }

--- a/src/main/java/com/iemr/admin/service/employeemaster/EmployeeMasterServiceImpl.java
+++ b/src/main/java/com/iemr/admin/service/employeemaster/EmployeeMasterServiceImpl.java
@@ -25,6 +25,7 @@ import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -1062,8 +1063,36 @@ public class EmployeeMasterServiceImpl implements EmployeeMasterInter {
 
 	@Override
 	public ArrayList<V_Showuser> getEmployeeDetails4(Integer serviceProviderID) {
+		ArrayList<V_Showuser> users = v_ShowuserRepo.EmployeeDetails4(serviceProviderID);
+		if (users.isEmpty()) {
+			return users;
+		}
 
-		return v_ShowuserRepo.EmployeeDetails4(serviceProviderID);
+		ArrayList<Integer> userIDs = new ArrayList<Integer>(users.size());
+		for (V_Showuser user : users) {
+			userIDs.add(user.getUserID());
+		}
+
+		Map<Integer, M_User1> userRecords = new HashMap<Integer, M_User1>();
+		for (M_User1 userRecord : employeeMasterRepoo.findByUserIDIn(userIDs)) {
+			userRecords.put(userRecord.getUserID(), userRecord);
+		}
+
+		for (V_Showuser user : users) {
+			enrichAccountLockState(user, userRecords.get(user.getUserID()));
+		}
+		return users;
+	}
+
+	private void enrichAccountLockState(V_Showuser user, M_User1 userRecord) {
+		if (userRecord == null) {
+			return;
+		}
+
+		Timestamp lockTimestamp = userRecord.getLockTimestamp();
+		user.setFailedAttempt(userRecord.getFailedAttempt() != null ? userRecord.getFailedAttempt() : 0);
+		user.setLockTimestamp(lockTimestamp);
+		user.setLockedDueToFailedAttempts(Boolean.TRUE.equals(userRecord.getDeleted()) && lockTimestamp != null);
 	}
 
 	@Override


### PR DESCRIPTION
Part of https://github.com/PSMRI/AMRIT/issues/118
## Description

Extends `m/SearchEmployee4` so Employee Master receives account lock state for every row when the list loads.

## Changes
- add failed-attempt lock metadata to the employee list response
- include `failedAttempt`, `lockTimestamp`, and `lockedDueToFailedAttempts`
- batch-load user lock metadata to avoid one query per listed user
- keep admin deactivation separate from failed-attempt lock state

## Why this shape was required
- review comments on the UI PR required lock/unlock status to come from `SearchEmployee4`
- the UI needs this data on initial load to render the correct Lock/Unlock control for each user