### PR TITLE
fix: allow reactivating legacy ASHA users with no facility mapped

### DIFF
--- a/src/main/java/com/iemr/admin/controller/employeemaster/EmployeeMasterController.java
+++ b/src/main/java/com/iemr/admin/controller/employeemaster/EmployeeMasterController.java
@@ -1848,6 +1848,10 @@ public class EmployeeMasterController {
 
 			M_UserServiceRoleMapping2 usrRole = employeeMasterInter.getDataUsrId(pre.getuSRMappingID());
 
+			// Fix 19: capture the DB deleted-flag BEFORE any mutation (this endpoint doesn't change
+			// it, but the flag must be read before mutation to be meaningful downstream)
+			boolean wasDeleted = Boolean.TRUE.equals(usrRole.getDeleted());
+
 			// Fix 1/3: cascade asha_supervisor_mapping BEFORE modifying entity to avoid JPA L1 cache issue
 			if (usrRole != null && usrRole.getUserID() != null) {
 				boolean roleChanged = pre.getRoleID() != null && usrRole.getRoleID() != null
@@ -1886,7 +1890,7 @@ public class EmployeeMasterController {
 				usrRole.setOutbound(pre.getOutbound());
 			}
 
-			M_UserServiceRoleMapping2 savedata = employeeMasterInter.saveRoleMappingeditedData(usrRole,
+			M_UserServiceRoleMapping2 savedata = employeeMasterInter.saveRoleMappingeditedData(usrRole, wasDeleted,
 					request.getHeader("Authorization"));
 
 			response.setResponse(savedata.toString());
@@ -1916,11 +1920,16 @@ public class EmployeeMasterController {
 
 			M_UserServiceRoleMapping2 usrRole = employeeMasterInter.getDataUsrId(pre.getuSRMappingID());
 
+			// Fix 19: capture the DB deleted-flag BEFORE any mutation, so saveRoleMappingeditedData
+			// can tell a reactivation apart from a fresh create/update without re-fetching (which
+			// would hit the JPA L1 cache and return this same already-mutated instance).
+			boolean wasDeleted = Boolean.TRUE.equals(usrRole.getDeleted());
+
 			// Fix 2: cascade asha_supervisor_mapping BEFORE setDeleted() to avoid JPA L1 cache issue.
 			// After setDeleted(true), findById() in saveRoleMappingeditedData hits the L1 cache
 			// returning the already-modified entity, so the "old vs new deleted" check always fails.
 			// For ASHA Supervisor with multiple facilities: only delete mappings for this facilityID
-			if (Boolean.TRUE.equals(pre.getDeleted()) && !Boolean.TRUE.equals(usrRole.getDeleted())
+			if (Boolean.TRUE.equals(pre.getDeleted()) && !wasDeleted
 					&& usrRole.getUserID() != null) {
 				logger.info("Fix2: cascading asha_supervisor_mapping soft-delete for userID={}, uSRMappingID={}",
 						usrRole.getUserID(), pre.getuSRMappingID());
@@ -1929,7 +1938,7 @@ public class EmployeeMasterController {
 
 			usrRole.setDeleted(pre.getDeleted());
 
-			M_UserServiceRoleMapping2 savedata = employeeMasterInter.saveRoleMappingeditedData(usrRole,
+			M_UserServiceRoleMapping2 savedata = employeeMasterInter.saveRoleMappingeditedData(usrRole, wasDeleted,
 					request.getHeader("Authorization"));
 
 			response.setResponse(savedata.toString());

--- a/src/main/java/com/iemr/admin/service/employeemaster/EmployeeMasterInter.java
+++ b/src/main/java/com/iemr/admin/service/employeemaster/EmployeeMasterInter.java
@@ -161,7 +161,10 @@ public interface EmployeeMasterInter {
 	M_UserServiceRoleMapping2 getDataUsrId(Integer uSRMappingID);
 
 //	M_UserServiceRoleMapping2 saveRoleMappingeditedData(M_UserServiceRoleMapping2 usrRole, String string);
-	public M_UserServiceRoleMapping2 saveRoleMappingeditedData(M_UserServiceRoleMapping2 usrRole, String authToken) throws JsonMappingException, JsonProcessingException;
+	// wasDeleted: the row's deleted flag as read from the DB BEFORE the caller mutated usrRole.
+	// Must be captured by the caller before mutation — a re-fetch here would hit the JPA L1 cache
+	// and return the already-mutated instance (Open-Session-In-View keeps one L1 cache per request).
+	public M_UserServiceRoleMapping2 saveRoleMappingeditedData(M_UserServiceRoleMapping2 usrRole, boolean wasDeleted, String authToken) throws JsonMappingException, JsonProcessingException;
 
 	// Fix 2: cascade soft-delete asha_supervisor_mapping rows when a user is deactivated
 	void cascadeDeleteAshaMappingsForUser(Integer userID);

--- a/src/main/java/com/iemr/admin/service/employeemaster/EmployeeMasterServiceImpl.java
+++ b/src/main/java/com/iemr/admin/service/employeemaster/EmployeeMasterServiceImpl.java
@@ -1043,16 +1043,26 @@ public class EmployeeMasterServiceImpl implements EmployeeMasterInter {
 	}
 
 	@Override
-	public M_UserServiceRoleMapping2 saveRoleMappingeditedData(M_UserServiceRoleMapping2 usrRole, String authToken) throws JsonMappingException, JsonProcessingException {
+	public M_UserServiceRoleMapping2 saveRoleMappingeditedData(M_UserServiceRoleMapping2 usrRole, boolean wasDeleted, String authToken) throws JsonMappingException, JsonProcessingException {
 
-		// Fix 4 + Fix 16 + Fix 17 + Fix 14: validate only on create/update, skip for deactivation
+		// Fix 4 + Fix 16 + Fix 17 + Fix 14: validate only on create/update, skip entirely for deactivation.
+		// Fix 19: on reactivation, waive ONLY Fix 4 (facility-mandatory) — legacy ASHA rows created
+		// before this rule existed may have no facility, and reactivation alone shouldn't be blocked
+		// by that. Fix 16/17 must still run whenever a facility IS present (reactivation or not), so
+		// a reactivated row can't silently resume pointing at a facility that went stale (soft-deleted,
+		// or no longer SC-level) while the user was inactive.
+		// wasDeleted is captured by the caller BEFORE usrRole is mutated — re-fetching it here via
+		// findById() would return the same JPA-managed instance as usrRole (Open-Session-In-View
+		// keeps one L1 cache per request), which already reflects the new (mutated) state.
 		M_Role role = null;
+		boolean isReactivation = usrRole.getuSRMappingID() != null && wasDeleted
+				&& Boolean.FALSE.equals(usrRole.getDeleted());
 		if (!Boolean.TRUE.equals(usrRole.getDeleted())) {
 			if (usrRole.getRoleID() != null) {
 				role = roleRepo.findByRoleID(usrRole.getRoleID());
-				// Fix 4: ASHA must have a facilityID
+				// Fix 4: ASHA must have a facilityID (waived on reactivation of a legacy row)
 				if (role != null && "asha".equalsIgnoreCase(role.getRoleName())
-						&& usrRole.getFacilityID() == null) {
+						&& usrRole.getFacilityID() == null && !isReactivation) {
 					throw new RuntimeException(
 							"Facility (SC) is mandatory for ASHA role. Please select a facility before saving.");
 				}


### PR DESCRIPTION
Reactivating a soft-deleted USR row was hitting "Facility (SC) is mandatory for ASHA role" for pre-existing ASHA users created before that rule existed, because the reactivation check re-fetched the row via findById() which returned the same JPA-managed instance already mutated by the caller (Open-Session-In-View shares one L1 cache per request), so the old-vs-new deleted comparison always failed.

saveRoleMappingeditedData now takes a wasDeleted flag captured by the caller before mutation, and waives only the facility-mandatory check on reactivation — facility soft-delete and SC-level checks still run whenever a facility is present, so a reactivated row can't silently resume pointing at a facility that went stale while inactive.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
